### PR TITLE
Update christian-riesen/base32 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.7",
-        "christian-riesen/base32": "~1.0",
+        "christian-riesen/base32": "~1.3",
         "simplesoftwareio/simple-qrcode" : "1.3.*"
     },
     "require-dev": {


### PR DESCRIPTION
Version 1.0 of _christian-riesen/base32_ is no longer available, and installations with composer fail:
> - pragmarx/google2fa v0.7.1 requires christian-riesen/base32 ~1.0 -> no matching package found.


This patch changes the version constraint to include the latest version and patch releases (1.3.*).